### PR TITLE
Add offline MSI installer + SignPath CI/CD signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,12 @@ name: build-and-sign-msi
 # offline-installable, SignPath-signed MSI (see issue #25).
 #
 # Required GitHub configuration (Settings -> Secrets and variables -> Actions):
-#   Secret    SIGNPATH_API_TOKEN                          - SignPath API token (submitter role)
-#   Variable  SIGNPATH_ORGANIZATION_ID                    - SignPath organization id (GUID)
-#   Variable  SIGNPATH_PROJECT_SLUG                       - SignPath project slug
-#   Variable  SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG    - artifact configuration slug for the MSI
+#   Secret  SIGNPATH_API_TOKEN  - SignPath API token (submitter role). This is the only secret.
+#
+# The non-secret SignPath identifiers (organization id, project slug, artifact-configuration slug)
+# are inlined in the sign-msi job below. The SignPath project must contain:
+#   - signing policies named 'test-signing' and 'release-signing'
+#   - an artifact configuration named 'msi' (see .signpath/artifact-config-msi.xml)
 # Also recommended: install the SignPath GitHub App on this repository.
 
 on:
@@ -107,15 +109,13 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          organization-id: '5539614d-dea7-4f4c-8d16-125276a14c03'
+          project-slug: 'barcodrod.io'
           signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY }}
-          artifact-configuration-slug: ${{ vars.SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG }}
+          artifact-configuration-slug: 'msi'
           github-artifact-id: ${{ steps.tosign.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: signed
-          parameters: |
-            version: "${{ needs.build-msi.outputs.version }}"
 
       - name: Upload signed MSI
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,12 @@ name: build-and-sign-msi
 #
 #   pull_request            -> build only (validates the installer builds)
 #   workflow_dispatch       -> build + SignPath test-signing (validate the signing pipeline)
-#   push tag 'v*'           -> build + SignPath release-signing + GitHub Release with checksums
+#     with production-preflight=true
+#                           -> build + SignPath *release-signing* against the production certificate,
+#                              WITHOUT creating any GitHub Release. Use this to prove the production
+#                              cert + artifact configuration work before cutting a tag. Never
+#                              repoint the test-signing policy at the production certificate.
+#   push tag 'v*'           -> build + SignPath release-signing + DRAFT GitHub Release with checksums
 #
 # The Microsoft Store continues to sign and distribute the MSIX; this workflow only produces the
 # offline-installable, SignPath-signed MSI (see issue #25).
@@ -18,20 +23,33 @@ name: build-and-sign-msi
 # The SignPath project must also contain signing policies named 'test-signing' and
 # 'release-signing', and an artifact configuration named per the variable above
 # (see .signpath/artifact-config-msi.xml). Also recommended: install the SignPath GitHub App.
+#
+# NOTE: the artifact configuration that actually runs lives in the SignPath portal. The XML in
+# .signpath/ is documentation/source-of-record only - keep them in sync by hand.
 
 on:
   push:
     tags: ['v*']
   pull_request:
   workflow_dispatch:
+    inputs:
+      production-preflight:
+        description: 'Sign with the production release-signing policy (no GitHub Release is created)'
+        type: boolean
+        default: false
+      preflight-version:
+        description: 'Version to stamp for a preflight build, e.g. 2.1.0.0 (blank = 0.0.0.<run>)'
+        type: string
+        default: ''
 
 permissions:
   contents: read
 
 env:
   WIX_VERSION: '5.0.2'
-  # Test policy for manual/dispatch validation; release (manual-approval) policy for version tags.
-  SIGNPATH_SIGNING_POLICY: ${{ startsWith(github.ref, 'refs/tags/v') && 'release-signing' || 'test-signing' }}
+  # Test policy for ordinary dispatch validation; the release (manual-approval) policy for version
+  # tags and for an explicit production preflight.
+  SIGNPATH_SIGNING_POLICY: ${{ (startsWith(github.ref, 'refs/tags/v') || inputs.production-preflight) && 'release-signing' || 'test-signing' }}
 
 jobs:
   build-msi:
@@ -55,6 +73,8 @@ jobs:
         run: |
           if ($env:GITHUB_REF -like 'refs/tags/v*') {
             $v = $env:GITHUB_REF -replace 'refs/tags/v', ''
+          } elseif ('${{ inputs.preflight-version }}') {
+            $v = '${{ inputs.preflight-version }}'
           } else {
             $v = "0.0.0.$($env:GITHUB_RUN_NUMBER)"
           }
@@ -70,6 +90,76 @@ jobs:
       - name: Build MSI (${{ matrix.arch }})
         shell: pwsh
         run: ./installer/build-msi.ps1 -Version ${{ steps.ver.outputs.version }} -Architecture ${{ matrix.arch }}
+
+      # Fail the build BEFORE burning a SignPath signing request if the metadata the artifact
+      # configuration enforces (product-name / product-version on the PEs, subject/author on the
+      # MSI) does not match what we are about to claim. A mismatch here would otherwise surface as
+      # a rejected signing request, or - worse - a release whose version metadata disagrees.
+      - name: Verify signing metadata (${{ matrix.arch }})
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $version = '${{ steps.ver.outputs.version }}'
+          $publish = "artifacts/publish/${{ matrix.arch }}"
+          $failures = @()
+
+          foreach ($name in 'barcodrod.io.exe', 'barcodrod.io.dll') {
+            $path = Join-Path $publish $name
+            if (-not (Test-Path $path)) { $failures += "MISSING: $path"; continue }
+            $info = (Get-Item $path).VersionInfo
+            if ($info.ProductName -ne 'barcodrod.io') {
+              $failures += "$name ProductName = '$($info.ProductName)' (expected 'barcodrod.io')"
+            }
+            if ($info.ProductVersion -ne $version) {
+              $failures += "$name ProductVersion = '$($info.ProductVersion)' (expected '$version')"
+            }
+            if ($info.FileVersion -ne $version) {
+              $failures += "$name FileVersion = '$($info.FileVersion)' (expected '$version')"
+            }
+            Write-Host "$name -> ProductName='$($info.ProductName)' ProductVersion='$($info.ProductVersion)' FileVersion='$($info.FileVersion)'"
+          }
+
+          $msi = Get-ChildItem "artifacts/msi/barcodrod.io-$version-${{ matrix.arch }}.msi"
+          $installer = New-Object -ComObject WindowsInstaller.Installer
+          $db = $installer.GetType().InvokeMember('OpenDatabase', 'InvokeMethod', $null, $installer, @($msi.FullName, 0))
+          function Get-MsiProperty($db, $name) {
+            $view = $db.GetType().InvokeMember('OpenView', 'InvokeMethod', $null, $db, @("SELECT Value FROM Property WHERE Property='$name'"))
+            $view.GetType().InvokeMember('Execute', 'InvokeMethod', $null, $view, $null) | Out-Null
+            $rec = $view.GetType().InvokeMember('Fetch', 'InvokeMethod', $null, $view, $null)
+            if ($null -eq $rec) { return $null }
+            return $rec.GetType().InvokeMember('StringData', 'GetProperty', $null, $rec, 1)
+          }
+          $msiVersion = Get-MsiProperty $db 'ProductVersion'
+          $upgradeCode = Get-MsiProperty $db 'UpgradeCode'
+          Write-Host "MSI -> ProductVersion='$msiVersion' UpgradeCode='$upgradeCode'"
+
+          # Windows Installer only honours the first three fields of ProductVersion, but WiX writes
+          # through whatever we pass in, so accept either the full four-part version or its
+          # three-part truncation. Verified locally: WiX 5.0.2 emits '2.1.0.0' for -d Version=2.1.0.0.
+          $shortMsiVersion = ($version.Split('.')[0..2] -join '.')
+          if ($msiVersion -ne $version -and $msiVersion -ne $shortMsiVersion) {
+            $failures += "MSI ProductVersion = '$msiVersion' (expected '$version' or '$shortMsiVersion')"
+          }
+          if ($upgradeCode -ne '{ADE87DB3-A892-4FF5-AF98-FCE2D5372793}') {
+            $failures += "MSI UpgradeCode = '$upgradeCode' (unexpected - breaks in-place upgrades)"
+          }
+
+          # On a release tag the shipped Store manifest must agree with the tag.
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            [xml]$manifest = Get-Content 'barcodrod.io/Package.appxmanifest'
+            $manifestVersion = $manifest.Package.Identity.Version
+            Write-Host "Package.appxmanifest -> Version='$manifestVersion'"
+            if ($manifestVersion -ne $version) {
+              $failures += "Package.appxmanifest Version = '$manifestVersion' (expected '$version' from the tag)"
+            }
+          }
+
+          if ($failures) {
+            Write-Host "::error::Signing metadata verification failed"
+            $failures | ForEach-Object { Write-Host "::error::$_" }
+            exit 1
+          }
+          Write-Host "All signing metadata checks passed."
 
       - name: Upload unsigned MSI
         uses: actions/upload-artifact@v4
@@ -116,6 +206,13 @@ jobs:
           artifact-configuration-slug: ${{ vars.SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG }}
           github-artifact-id: ${{ steps.tosign.outputs.artifact-id }}
           wait-for-completion: true
+          # The Foundation program requires manual approval of every release signing request, which
+          # can easily exceed the action's 30 minute default.
+          wait-for-completion-timeout-in-seconds: '7200'
+          # The artifact configuration declares a required 'version' parameter and enforces it as PE
+          # product-version metadata. Values must be valid JSON strings, hence the quotes.
+          parameters: |
+            version: "${{ needs.build-msi.outputs.version }}"
           output-artifact-directory: signed
 
       - name: Upload signed MSI
@@ -132,12 +229,38 @@ jobs:
     permissions:
       contents: write
     steps:
+      # Needed for the CHANGELOG section used as the release body.
+      - uses: actions/checkout@v4
+
       - name: Download signed MSIs
         uses: actions/download-artifact@v4
         with:
           pattern: msi-signed-*
           path: dist
           merge-multiple: true
+
+      # Guard against a partial or duplicated signing matrix producing a malformed release.
+      - name: Verify release assets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $msis = @(Get-ChildItem dist -Recurse -Filter *.msi)
+          $msis | ForEach-Object { Write-Host "found: $($_.Name)" }
+          $x64 = @($msis | Where-Object { $_.Name -like '*-x64.msi' })
+          $arm64 = @($msis | Where-Object { $_.Name -like '*-arm64.msi' })
+          $failures = @()
+          if ($x64.Count -ne 1) { $failures += "expected exactly 1 x64 MSI, found $($x64.Count)" }
+          if ($arm64.Count -ne 1) { $failures += "expected exactly 1 arm64 MSI, found $($arm64.Count)" }
+          if ($msis.Count -ne 2) { $failures += "expected exactly 2 MSIs, found $($msis.Count)" }
+          foreach ($m in $msis) {
+            $sig = Get-AuthenticodeSignature $m.FullName
+            Write-Host "$($m.Name) -> signature status: $($sig.Status), signer: $($sig.SignerCertificate.Subject)"
+            if ($sig.Status -eq 'NotSigned') { $failures += "$($m.Name) is not signed" }
+          }
+          if ($failures) {
+            $failures | ForEach-Object { Write-Host "::error::$_" }
+            exit 1
+          }
 
       - name: Generate SHA256 checksums
         shell: pwsh
@@ -147,10 +270,49 @@ jobs:
           $lines | Out-File dist/SHA256SUMS.txt -Encoding ascii
           $lines | Write-Host
 
-      - name: Create GitHub Release
+      - name: Build release notes from CHANGELOG
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $tag = $env:GITHUB_REF_NAME
+          $lines = Get-Content CHANGELOG.md
+          $start = -1
+          for ($i = 0; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match "^##\s+$([regex]::Escape($tag))\s*$") { $start = $i + 1; break }
+          }
+          if ($start -lt 0) {
+            Write-Host "::error::No '## $tag' section found in CHANGELOG.md"
+            exit 1
+          }
+          $end = $lines.Count
+          for ($i = $start; $i -lt $lines.Count; $i++) {
+            if ($lines[$i] -match '^##\s+') { $end = $i; break }
+          }
+          if ($end -le $start) {
+            Write-Host "::error::The '## $tag' CHANGELOG section is empty"
+            exit 1
+          }
+          $body = $lines[$start..($end - 1)] -join "`n"
+          $body = $body.Trim()
+          if (-not $body) {
+            Write-Host "::error::The '## $tag' CHANGELOG section is empty"
+            exit 1
+          }
+          $body | Out-File release-notes.md -Encoding utf8
+          Write-Host $body
+
+      # Created as a DRAFT on purpose: asset uploads are not atomic, and the signed MSIs must be
+      # installed and smoke-tested on clean x64 and arm64 machines before anything is public.
+      # Publish manually (gh release edit <tag> --draft=false) once verified.
+      - name: Create draft GitHub Release
         shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           $assets = Get-ChildItem dist -Recurse -File | ForEach-Object { $_.FullName }
-          gh release create "$env:GITHUB_REF_NAME" $assets --title "$env:GITHUB_REF_NAME" --generate-notes
+          gh release create "$env:GITHUB_REF_NAME" $assets `
+            --title "$env:GITHUB_REF_NAME" `
+            --notes-file release-notes.md `
+            --verify-tag `
+            --draft
+          Write-Host "::notice::Draft release created. Smoke-test the signed MSIs, then publish with: gh release edit $env:GITHUB_REF_NAME --draft=false"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,155 @@
+name: build-and-sign-msi
+
+# Builds the classic (unpackaged) barcodrod.io MSI for x64 and arm64 and code-signs it via SignPath.
+#
+#   pull_request            -> build only (validates the installer builds)
+#   workflow_dispatch       -> build + SignPath test-signing (validate the signing pipeline)
+#   push tag 'v*'           -> build + SignPath release-signing + GitHub Release with checksums
+#
+# The Microsoft Store continues to sign and distribute the MSIX; this workflow only produces the
+# offline-installable, SignPath-signed MSI (see issue #25).
+#
+# Required GitHub configuration (Settings -> Secrets and variables -> Actions):
+#   Secret    SIGNPATH_API_TOKEN                          - SignPath API token (submitter role)
+#   Variable  SIGNPATH_ORGANIZATION_ID                    - SignPath organization id (GUID)
+#   Variable  SIGNPATH_PROJECT_SLUG                       - SignPath project slug
+#   Variable  SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG    - artifact configuration slug for the MSI
+# Also recommended: install the SignPath GitHub App on this repository.
+
+on:
+  push:
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  WIX_VERSION: '5.0.2'
+  # Test policy for manual/dispatch validation; release (manual-approval) policy for version tags.
+  SIGNPATH_SIGNING_POLICY: ${{ startsWith(github.ref, 'refs/tags/v') && 'release-signing' || 'test-signing' }}
+
+jobs:
+  build-msi:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Derive version
+        id: ver
+        shell: pwsh
+        run: |
+          if ($env:GITHUB_REF -like 'refs/tags/v*') {
+            $v = $env:GITHUB_REF -replace 'refs/tags/v', ''
+          } else {
+            $v = "0.0.0.$($env:GITHUB_RUN_NUMBER)"
+          }
+          $parts = @($v.Split('.'))
+          while ($parts.Count -lt 4) { $parts += '0' }
+          $v = ($parts[0..3] -join '.')
+          "version=$v" | Out-File $env:GITHUB_OUTPUT -Append
+          Write-Host "Resolved version: $v"
+
+      - name: Install WiX ${{ env.WIX_VERSION }}
+        run: dotnet tool install --global wix --version ${{ env.WIX_VERSION }}
+
+      - name: Build MSI (${{ matrix.arch }})
+        shell: pwsh
+        run: ./installer/build-msi.ps1 -Version ${{ steps.ver.outputs.version }} -Architecture ${{ matrix.arch }}
+
+      - name: Upload unsigned MSI
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-unsigned-${{ matrix.arch }}
+          path: artifacts/msi/barcodrod.io-*-${{ matrix.arch }}.msi
+          if-no-files-found: error
+
+  sign-msi:
+    # Sign on version tags (release) and on manual dispatch (test). PR builds are validate-only and
+    # do not have access to the signing secret (e.g. fork PRs), so they are intentionally excluded.
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    needs: build-msi
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Download unsigned MSI
+        uses: actions/download-artifact@v4
+        with:
+          name: msi-unsigned-${{ matrix.arch }}
+          path: unsigned
+
+      - name: Re-upload artifact for signing
+        id: tosign
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-tosign-${{ matrix.arch }}
+          path: unsigned/*.msi
+          if-no-files-found: error
+
+      - name: Submit signing request to SignPath
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY }}
+          artifact-configuration-slug: ${{ vars.SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.tosign.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed
+          parameters: |
+            version: "${{ needs.build-msi.outputs.version }}"
+
+      - name: Upload signed MSI
+        uses: actions/upload-artifact@v4
+        with:
+          name: msi-signed-${{ matrix.arch }}
+          path: signed/**/*.msi
+          if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: sign-msi
+    runs-on: windows-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download signed MSIs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: msi-signed-*
+          path: dist
+          merge-multiple: true
+
+      - name: Generate SHA256 checksums
+        shell: pwsh
+        run: |
+          $lines = Get-ChildItem dist -Recurse -Filter *.msi |
+            ForEach-Object { '{0}  {1}' -f (Get-FileHash $_.FullName -Algorithm SHA256).Hash, $_.Name }
+          $lines | Out-File dist/SHA256SUMS.txt -Encoding ascii
+          $lines | Write-Host
+
+      - name: Create GitHub Release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $assets = Get-ChildItem dist -Recurse -File | ForEach-Object { $_.FullName }
+          gh release create "$env:GITHUB_REF_NAME" $assets --title "$env:GITHUB_REF_NAME" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,14 @@ name: build-and-sign-msi
 # offline-installable, SignPath-signed MSI (see issue #25).
 #
 # Required GitHub configuration (Settings -> Secrets and variables -> Actions):
-#   Secret  SIGNPATH_API_TOKEN  - SignPath API token (submitter role). This is the only secret.
+#   Secret    SIGNPATH_API_TOKEN                          - SignPath API token (submitter role)
+#   Variable  SIGNPATH_ORGANIZATION_ID                    - SignPath organization id (GUID)
+#   Variable  SIGNPATH_PROJECT_SLUG                       - SignPath project slug
+#   Variable  SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG    - artifact configuration slug (e.g. 'msi')
 #
-# The non-secret SignPath identifiers (organization id, project slug, artifact-configuration slug)
-# are inlined in the sign-msi job below. The SignPath project must contain:
-#   - signing policies named 'test-signing' and 'release-signing'
-#   - an artifact configuration named 'msi' (see .signpath/artifact-config-msi.xml)
-# Also recommended: install the SignPath GitHub App on this repository.
+# The SignPath project must also contain signing policies named 'test-signing' and
+# 'release-signing', and an artifact configuration named per the variable above
+# (see .signpath/artifact-config-msi.xml). Also recommended: install the SignPath GitHub App.
 
 on:
   push:
@@ -109,10 +110,10 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: '5539614d-dea7-4f4c-8d16-125276a14c03'
-          project-slug: 'barcodrod.io'
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
           signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY }}
-          artifact-configuration-slug: 'msi'
+          artifact-configuration-slug: ${{ vars.SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG }}
           github-artifact-id: ${{ steps.tosign.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: signed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ name: build-and-sign-msi
 #   Secret    SIGNPATH_API_TOKEN                          - SignPath API token (submitter role)
 #   Variable  SIGNPATH_ORGANIZATION_ID                    - SignPath organization id (GUID)
 #   Variable  SIGNPATH_PROJECT_SLUG                       - SignPath project slug
-#   Variable  SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG    - artifact configuration slug (e.g. 'msi')
+#   Variable  SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG    - artifact configuration slug ('deep-sign')
 #
 # The SignPath project must also contain signing policies named 'test-signing' and
 # 'release-signing', and an artifact configuration named per the variable above

--- a/.gitignore
+++ b/.gitignore
@@ -400,3 +400,6 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# Internal planning doc (not part of the repo)
+plan.md

--- a/.gitignore
+++ b/.gitignore
@@ -403,3 +403,4 @@ FodyWeavers.xsd
 
 # Internal planning doc (not part of the repo)
 plan.md
+PROD-CUTOVER.md

--- a/.signpath/artifact-config-msi.xml
+++ b/.signpath/artifact-config-msi.xml
@@ -2,14 +2,15 @@
 <!--
   SignPath artifact configuration for the barcodrod.io MSI.
 
-  This mirrors SignPath's built-in "Windows Installer (.msi)" template: it Authenticode-signs the
-  MSI package itself, which is what Windows / SmartScreen verifies when a user runs the installer
+  IMPORTANT: actions/upload-artifact always packs the uploaded file(s) into a ZIP, so the artifact
+  SignPath receives is a ZIP that contains the .msi. The configuration root must therefore be a
+  <zip-file> wrapping the <msi-file> (per SignPath's GitHub Actions guidance). It Authenticode-signs
+  the MSI package itself, which is what Windows / SmartScreen verifies when a user runs the installer
   (the goal of issue #25). Upstream OSS binaries inside the MSI are shipped as-is and are not signed
   with this certificate, as permitted by the SignPath Foundation OSS terms.
 
-  In the SignPath portal, create an artifact configuration named "msi" (slug: msi) and either keep
-  the default "Windows Installer (.msi)" template (equivalent to this) or paste this XML via
-  "Customize".
+  In the SignPath portal, the artifact configuration (slug 'msi-github') must use this exact XML
+  (Project -> Artifact Configurations -> select 'msi-github' -> Edit -> paste).
 
   Optional hardening for the production SignPath Foundation certificate (add later and validate
   against a real MSI sample via "Update from an artifact sample"): deep-sign the first-party binaries
@@ -18,20 +19,24 @@
     <parameters>
       <parameter name="version" required="true" />
     </parameters>
-    <msi-file>
-      <pe-file-set product-name="barcodrod.io" product-version="${version}">
-        <include path="barcodrod.io.exe" />
-        <include path="barcodrod.io.dll" />
-        <for-each><authenticode-sign /></for-each>
-      </pe-file-set>
-      <authenticode-sign />
-    </msi-file>
+    <zip-file>
+      <msi-file path="*.msi">
+        <pe-file-set product-name="barcodrod.io" product-version="${version}">
+          <include path="barcodrod.io.exe" />
+          <include path="barcodrod.io.dll" />
+          <for-each><authenticode-sign /></for-each>
+        </pe-file-set>
+        <authenticode-sign />
+      </msi-file>
+    </zip-file>
 
   If you enable the parameterized version above, also re-add the matching `parameters:` block to the
   sign-msi step in .github/workflows/release.yml.
 -->
 <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
-  <msi-file>
-    <authenticode-sign />
-  </msi-file>
+  <zip-file>
+    <msi-file path="*.msi">
+      <authenticode-sign />
+    </msi-file>
+  </zip-file>
 </artifact-configuration>

--- a/.signpath/artifact-config-msi.xml
+++ b/.signpath/artifact-config-msi.xml
@@ -4,38 +4,40 @@
 
   IMPORTANT: actions/upload-artifact always packs the uploaded file(s) into a ZIP, so the artifact
   SignPath receives is a ZIP that contains the .msi. The configuration root must therefore be a
-  <zip-file> wrapping the <msi-file> (per SignPath's GitHub Actions guidance). It Authenticode-signs
-  the MSI package itself, which is what Windows / SmartScreen verifies when a user runs the installer
-  (the goal of issue #25). Upstream OSS binaries inside the MSI are shipped as-is and are not signed
-  with this certificate, as permitted by the SignPath Foundation OSS terms.
+  <zip-file> wrapping the <msi-file> (per SignPath's GitHub Actions guidance). It deep-signs the
+  first-party binaries and Authenticode-signs the MSI package itself, which is what Windows /
+  SmartScreen verifies when a user runs the installer (the goal of issue #25).
 
   In the SignPath portal, the artifact configuration (slug 'msi-github') must use this exact XML
-  (Project -> Artifact Configurations -> select 'msi-github' -> Edit -> paste).
+  (Project -> Artifact Configurations -> select 'msi-github' -> Edit -> paste). Editing this file
+  alone changes NOTHING: the portal configuration is the source of truth at signing time.
 
-  Optional hardening for the production SignPath Foundation certificate (add later and validate
-  against a real MSI sample via "Update from an artifact sample"): deep-sign the first-party binaries
-  and enforce product-name / product-version metadata, e.g.
+  Foundation program compliance (https://signpath.org - Foundation terms):
+    * "All signed binaries must have metadata attributes set and enforced using file metadata
+      restrictions" -> hence the product-name / product-version restrictions below.
+    * "The team must only sign software artifacts built from their own source code", while
+      "You may include unsigned binaries of upstream OSS projects, e.g. DLL files, in your signed
+      packages" -> hence ONLY barcodrod.io.exe and barcodrod.io.dll are deep-signed. The bundled
+      .NET runtime, Windows App SDK, ZXing.Net and AForge.NET binaries are shipped as-is, unsigned.
 
-    <parameters>
-      <parameter name="version" required="true" />
-    </parameters>
-    <zip-file>
-      <msi-file path="*.msi">
-        <pe-file-set product-name="barcodrod.io" product-version="${version}">
-          <include path="barcodrod.io.exe" />
-          <include path="barcodrod.io.dll" />
-          <for-each><authenticode-sign /></for-each>
-        </pe-file-set>
-        <authenticode-sign />
-      </msi-file>
-    </zip-file>
-
-  If you enable the parameterized version above, also re-add the matching `parameters:` block to the
-  sign-msi step in .github/workflows/release.yml.
+  The ${version} parameter is supplied by the sign-msi step in .github/workflows/release.yml and
+  must match the PE ProductVersion stamped by installer/build-msi.ps1 (-p:InformationalVersion) and
+  the MSI subject built from installer/barcodrod.io.wxs. Validate against a real MSI sample via
+  the portal's "Update from an artifact sample" before the first production signing run.
 -->
 <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <parameters>
+    <parameter name="version" required="true" />
+  </parameters>
   <zip-file>
-    <msi-file path="*.msi">
+    <msi-file path="*.msi" subject="barcodrod.io ${version} installer" author="Mark Hopper">
+      <pe-file-set product-name="barcodrod.io" product-version="${version}">
+        <include path="barcodrod.io.exe" />
+        <include path="barcodrod.io.dll" />
+        <for-each>
+          <authenticode-sign />
+        </for-each>
+      </pe-file-set>
       <authenticode-sign />
     </msi-file>
   </zip-file>

--- a/.signpath/artifact-config-msi.xml
+++ b/.signpath/artifact-config-msi.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  SignPath artifact configuration for the barcodrod.io MSI.
+
+  - Deep-signs the first-party binaries (barcodrod.io.exe / barcodrod.io.dll) and enforces the
+    SignPath OSS metadata requirements: product name + product version must be set and match.
+    The build stamps these via installer/build-msi.ps1 (-p:FileVersion / -p:InformationalVersion),
+    and the workflow passes the matching value in the `version` parameter.
+  - Signs the MSI package itself.
+  - Third-party / upstream OSS binaries (ZXing.Net, AForge, CommunityToolkit, the Windows App SDK
+    runtime, etc.) are shipped as-is and are not signed with this certificate, as permitted by the
+    SignPath Foundation OSS terms.
+
+  Validate this against a real MSI by uploading a sample in the SignPath project
+  (Artifact Configurations -> Update from an artifact sample) and adjusting file paths if needed.
+-->
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <parameters>
+    <parameter name="version" required="true" />
+  </parameters>
+  <msi-file>
+    <pe-file-set product-name="barcodrod.io" product-version="${version}">
+      <include path="barcodrod.io.exe" />
+      <include path="barcodrod.io.dll" />
+      <for-each>
+        <authenticode-sign />
+      </for-each>
+    </pe-file-set>
+    <authenticode-sign />
+  </msi-file>
+</artifact-configuration>

--- a/.signpath/artifact-config-msi.xml
+++ b/.signpath/artifact-config-msi.xml
@@ -33,8 +33,17 @@
   <zip-file>
     <msi-file path="*.msi" subject="barcodrod.io ${version} installer" author="Mark Hopper">
       <pe-file-set product-name="barcodrod.io" product-version="${version}">
-        <include path="barcodrod.io.exe" />
-        <include path="barcodrod.io.dll" />
+        <!--
+          The '**/' prefix is REQUIRED. WiX installs into ProgramFiles64Folder\barcodrod.io, so
+          inside the MSI these binaries are nested three directory levels deep
+          (verified against a real MSI: SourceDir/PFiles64/barcodrod.io/barcodrod.io.exe) rather
+          than sitting at the package root. A bare 'barcodrod.io.exe' matches 0 items and the
+          signing request fails with "Expected path to match exactly 1 item, but found 0".
+          min-matches/max-matches both default to 1, so these still assert exactly one match each -
+          the localized satellite assemblies are named barcodrod.io.resources.dll and do not collide.
+        -->
+        <include path="**/barcodrod.io.exe" />
+        <include path="**/barcodrod.io.dll" />
         <for-each>
           <authenticode-sign />
         </for-each>

--- a/.signpath/artifact-config-msi.xml
+++ b/.signpath/artifact-config-msi.xml
@@ -2,30 +2,36 @@
 <!--
   SignPath artifact configuration for the barcodrod.io MSI.
 
-  - Deep-signs the first-party binaries (barcodrod.io.exe / barcodrod.io.dll) and enforces the
-    SignPath OSS metadata requirements: product name + product version must be set and match.
-    The build stamps these via installer/build-msi.ps1 (-p:FileVersion / -p:InformationalVersion),
-    and the workflow passes the matching value in the `version` parameter.
-  - Signs the MSI package itself.
-  - Third-party / upstream OSS binaries (ZXing.Net, AForge, CommunityToolkit, the Windows App SDK
-    runtime, etc.) are shipped as-is and are not signed with this certificate, as permitted by the
-    SignPath Foundation OSS terms.
+  This mirrors SignPath's built-in "Windows Installer (.msi)" template: it Authenticode-signs the
+  MSI package itself, which is what Windows / SmartScreen verifies when a user runs the installer
+  (the goal of issue #25). Upstream OSS binaries inside the MSI are shipped as-is and are not signed
+  with this certificate, as permitted by the SignPath Foundation OSS terms.
 
-  Validate this against a real MSI by uploading a sample in the SignPath project
-  (Artifact Configurations -> Update from an artifact sample) and adjusting file paths if needed.
+  In the SignPath portal, create an artifact configuration named "msi" (slug: msi) and either keep
+  the default "Windows Installer (.msi)" template (equivalent to this) or paste this XML via
+  "Customize".
+
+  Optional hardening for the production SignPath Foundation certificate (add later and validate
+  against a real MSI sample via "Update from an artifact sample"): deep-sign the first-party binaries
+  and enforce product-name / product-version metadata, e.g.
+
+    <parameters>
+      <parameter name="version" required="true" />
+    </parameters>
+    <msi-file>
+      <pe-file-set product-name="barcodrod.io" product-version="${version}">
+        <include path="barcodrod.io.exe" />
+        <include path="barcodrod.io.dll" />
+        <for-each><authenticode-sign /></for-each>
+      </pe-file-set>
+      <authenticode-sign />
+    </msi-file>
+
+  If you enable the parameterized version above, also re-add the matching `parameters:` block to the
+  sign-msi step in .github/workflows/release.yml.
 -->
 <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
-  <parameters>
-    <parameter name="version" required="true" />
-  </parameters>
   <msi-file>
-    <pe-file-set product-name="barcodrod.io" product-version="${version}">
-      <include path="barcodrod.io.exe" />
-      <include path="barcodrod.io.dll" />
-      <for-each>
-        <authenticode-sign />
-      </for-each>
-    </pe-file-set>
     <authenticode-sign />
   </msi-file>
 </artifact-configuration>

--- a/.signpath/artifact-config-msi.xml
+++ b/.signpath/artifact-config-msi.xml
@@ -8,8 +8,9 @@
   first-party binaries and Authenticode-signs the MSI package itself, which is what Windows /
   SmartScreen verifies when a user runs the installer (the goal of issue #25).
 
-  In the SignPath portal, the artifact configuration (slug 'msi-github') must use this exact XML
-  (Project -> Artifact Configurations -> select 'msi-github' -> Edit -> paste). Editing this file
+  In the SignPath portal, the artifact configuration (slug 'deep-sign', pointed at by the
+  SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG repository variable) must use this exact XML
+  (Project -> Artifact Configurations -> select 'deep-sign' -> Edit -> paste). Editing this file
   alone changes NOTHING: the portal configuration is the source of truth at signing time.
 
   Foundation program compliance (https://signpath.org - Foundation terms):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,59 +2,114 @@
 
 ## Unreleased
 
+### Added â€” CI/CD code signing (SignPath) for the MSI
+
+- **GitHub Actions release workflow** â€” Added `.github/workflows/release.yml`, which builds the MSI
+  for **x64 and arm64** on GitHub-hosted runners (via `installer/build-msi.ps1`) and code-signs it
+  through the [SignPath Foundation](https://signpath.org) OSS program: `workflow_dispatch` test-signs
+  (validation), version tags `v*` release-sign (manual approval) and publish a GitHub Release with
+  `SHA256SUMS.txt`, and pull requests build only. SignPath org/project/policy values are read from
+  GitHub Actions variables/secret (`SIGNPATH_*`), so nothing sensitive is committed. The Microsoft
+  Store continues to sign and distribute the MSIX.
+- **SignPath artifact configuration** â€” Added `.signpath/artifact-config-msi.xml`, which deep-signs
+  the first-party binaries with enforced `product-name`/`product-version` metadata and signs the MSI.
+- **Deterministic version stamping** â€” `installer/build-msi.ps1` now stamps the published binaries'
+  `FileVersion`/`ProductVersion` from the build version so SignPath's metadata restriction is
+  enforceable; the arm64 build path and `resources.pri` staging were made architecture-robust.
+
+### Changed
+
+- **`barcodrod.io.csproj` cleanup** â€” Removed the duplicate `GenerateTemporaryStoreCertificate`
+  property and replaced the hardcoded `AppxPackageDir` (`D:\barcodrod.io_builds\`) with a
+  repo-relative default so CI and other contributors don't depend on a machine-specific path.
+
+### Added â€” Classic (unpackaged) MSI installer
+
+- **Standalone MSI installer** â€” Added `installer/barcodrod.io.wxs` (WiX v5) and
+  `installer/build-msi.ps1` to produce a classic, fully **unpackaged** MSI that installs
+  barcodrod.io into Program Files with a Start Menu shortcut and Add/Remove Programs entry. The app
+  runs with no MSIX, no Microsoft Store, and no Store license, enabling offline and locked-down
+  environments (addresses #25). The installer auto-harvests the published output (no hand-maintained
+  file list).
+
+- **File type associations (MSI â†” MSIX parity)** â€” The MSI registers a `barcodrod.io.image` ProgID
+  and advertises barcodrod.io in the Windows "Open with" list for the same 14 image extensions as the
+  MSIX manifest (`.jpg .jpeg .png .bmp .gif .tif .tiff .webp .heif .heic .jfif .ico .svg .jp2`).
+  `App.OnLaunched` now also accepts the file path from the command line, since a classic file
+  association passes the file as an argument rather than via the packaged File activation contract.
+
+- **Toast notification COM activator (MSI â†” MSIX parity)** â€” The MSI registers
+  `HKCR\CLSID\{DD6D181A-17B6-4A3A-9E66-B9399E0F1184}\LocalServer32` and sets
+  `System.AppUserModel.ToastActivatorCLSID` on the Start Menu shortcut, mirroring the MSIX manifest's
+  `windows.comServer` toast activator one-to-one.
+
+### Bug Fixes â€” Unpackaged execution
+
+- **App now runs unpackaged** â€” Added `Helpers/AppPaths.cs` (`LocalDataFolder` /
+  `GetLocalFolderAsync()`) which returns the app data folder via `ApplicationData.Current.LocalFolder`
+  when packaged and `%LOCALAPPDATA%\barcodrod.io` (`StorageFolder.GetFolderFromPathAsync`) when
+  unpackaged. Replaced all ~44 unguarded `ApplicationData.Current.LocalFolder` usages across
+  `MainWindow`, `SettingsPage`, `HistoryPage`, `EncodePage`, `DecodePage`, and
+  `DefaultActivationHandler` with this helper. `ApplicationData.Current` throws without package
+  identity, which previously caused the unpackaged app to start with no window.
+
+- **Unhandled exceptions are now logged** â€” `App.App_UnhandledException` writes to
+  `%LOCALAPPDATA%\barcodrod.io\crash.log` instead of silently swallowing exceptions (`e.Handled` is
+  still set to keep prior behaviour). This surfaced the unpackaged startup failures above.
+
 ### Bug Fixes
 
-- **Fixed `TextWrapping="WrapWholeWords"` build errors** — Replaced invalid `WrapWholeWords` values with `Wrap` on the `EmailBody` RichEditBox and `SameColorWarning` TextBlock in `EncodePage.xaml`. `WrapWholeWords` is not a valid value for the WinUI `TextWrapping` property.
+- **Fixed `TextWrapping="WrapWholeWords"` build errors** ï¿½ Replaced invalid `WrapWholeWords` values with `Wrap` on the `EmailBody` RichEditBox and `SameColorWarning` TextBlock in `EncodePage.xaml`. `WrapWholeWords` is not a valid value for the WinUI `TextWrapping` property.
 
-- **Fixed `WindowsBase` assembly version conflict** — Downgraded `ZXing.Net.Bindings.Windows.Compatibility` from `0.16.14` to `0.16.11` in `barcodrod.io.csproj` to align with `ZXing.Net` `0.16.11` and resolve a conflict between `WindowsBase` 4.0.0.0 and 9.0.0.0. Removed the unused ZXing package references from `barcodrod.io.Core.csproj`.
+- **Fixed `WindowsBase` assembly version conflict** ï¿½ Downgraded `ZXing.Net.Bindings.Windows.Compatibility` from `0.16.14` to `0.16.11` in `barcodrod.io.csproj` to align with `ZXing.Net` `0.16.11` and resolve a conflict between `WindowsBase` 4.0.0.0 and 9.0.0.0. Removed the unused ZXing package references from `barcodrod.io.Core.csproj`.
 
-- **Fixed window icon not showing** — Removed the `<Content Remove="Assets\WindowIcon.ico" />` line from `barcodrod.io.csproj` that was preventing the icon from being deployed to the output directory, which caused `AppWindow.SetIcon()` in `MainWindow.xaml.cs` to fail silently at runtime.
+- **Fixed window icon not showing** ï¿½ Removed the `<Content Remove="Assets\WindowIcon.ico" />` line from `barcodrod.io.csproj` that was preventing the icon from being deployed to the output directory, which caused `AppWindow.SetIcon()` in `MainWindow.xaml.cs` to fail silently at runtime.
 
-### Removed — MVVM Template Cleanup
+### Removed ï¿½ MVVM Template Cleanup
 
 Removed unused scaffolding left over from the WinUI Community MVVM template that was never wired up:
 
 - **Deleted empty ViewModels:**
-  - `ViewModels/DecodeViewModel.cs` — empty class, never used by `DecodePage`
-  - `ViewModels/EncodeViewModel.cs` — empty class, `EncodePage` declared but never used its `ViewModel` property
-  - `ViewModels/HistoryViewModel.cs` — empty class, `HistoryPage` called `App.GetService<HistoryViewModel>()` but discarded the result
+  - `ViewModels/DecodeViewModel.cs` ï¿½ empty class, never used by `DecodePage`
+  - `ViewModels/EncodeViewModel.cs` ï¿½ empty class, `EncodePage` declared but never used its `ViewModel` property
+  - `ViewModels/HistoryViewModel.cs` ï¿½ empty class, `HistoryPage` called `App.GetService<HistoryViewModel>()` but discarded the result
 
 - **Deleted unused Behaviors:**
-  - `Behaviors/NavigationViewHeaderBehavior.cs` — not referenced in `ShellPage.xaml` (the `Interaction.Behaviors` block was empty)
-  - `Behaviors/NavigationViewHeaderMode.cs` — only used by the removed `NavigationViewHeaderBehavior`
+  - `Behaviors/NavigationViewHeaderBehavior.cs` ï¿½ not referenced in `ShellPage.xaml` (the `Interaction.Behaviors` block was empty)
+  - `Behaviors/NavigationViewHeaderMode.cs` ï¿½ only used by the removed `NavigationViewHeaderBehavior`
 
 - **Deleted unused Helpers/Contracts:**
-  - `Helpers/SettingsStorageExtensions.cs` — never called from any code
-  - `Helpers/FrameExtensions.cs` — only used for `INavigationAware` checks which never triggered
-  - `Contracts/ViewModels/INavigationAware.cs` — no class ever implemented this interface
+  - `Helpers/SettingsStorageExtensions.cs` ï¿½ never called from any code
+  - `Helpers/FrameExtensions.cs` ï¿½ only used for `INavigationAware` checks which never triggered
+  - `Contracts/ViewModels/INavigationAware.cs` ï¿½ no class ever implemented this interface
 
-- **Removed `barcodrod.io.Core` project dependency** — The Core project (`IFileService`, `FileService`, `Json` helper) was only consumed by `LocalSettingsService`. These three files were inlined into the main project under their equivalent namespaces:
+- **Removed `barcodrod.io.Core` project dependency** ï¿½ The Core project (`IFileService`, `FileService`, `Json` helper) was only consumed by `LocalSettingsService`. These three files were inlined into the main project under their equivalent namespaces:
   - `barcodrod.io.Core/Contracts/Services/IFileService.cs` ? `barcodrod.io/Contracts/Services/IFileService.cs`
   - `barcodrod.io.Core/Services/FileService.cs` ? `barcodrod.io/Services/FileService.cs`
   - `barcodrod.io.Core/Helpers/Json.cs` ? `barcodrod.io/Helpers/Json.cs`
 
-### Changed — Refactored Files
+### Changed ï¿½ Refactored Files
 
-- **`App.xaml.cs`** — Removed DI registrations for `DecodeViewModel`, `EncodeViewModel`, `HistoryViewModel`. Removed `barcodrod.io.Core` using statements. Replaced with local `barcodrod.io` namespace references.
+- **`App.xaml.cs`** ï¿½ Removed DI registrations for `DecodeViewModel`, `EncodeViewModel`, `HistoryViewModel`. Removed `barcodrod.io.Core` using statements. Replaced with local `barcodrod.io` namespace references.
 
-- **`Services/PageService.cs`** — Refactored from `Configure<VM, V>()` (which required ViewModel types) to `Configure<V>(string key)` using string navigation keys directly, eliminating the dependency on ViewModel classes.
+- **`Services/PageService.cs`** ï¿½ Refactored from `Configure<VM, V>()` (which required ViewModel types) to `Configure<V>(string key)` using string navigation keys directly, eliminating the dependency on ViewModel classes.
 
-- **`Services/NavigationService.cs`** — Removed all `INavigationAware` checks from `GoBack()`, `NavigateTo()`, and `OnNavigated()`. Removed `FrameExtensions` usage. Removed `barcodrod.io.Contracts.ViewModels` using.
+- **`Services/NavigationService.cs`** ï¿½ Removed all `INavigationAware` checks from `GoBack()`, `NavigateTo()`, and `OnNavigated()`. Removed `FrameExtensions` usage. Removed `barcodrod.io.Contracts.ViewModels` using.
 
-- **`Services/NavigationViewService.cs`** — Replaced `typeof(SettingsViewModel).FullName!` with the string literal `"barcodrod.io.ViewModels.SettingsViewModel"`.
+- **`Services/NavigationViewService.cs`** ï¿½ Replaced `typeof(SettingsViewModel).FullName!` with the string literal `"barcodrod.io.ViewModels.SettingsViewModel"`.
 
-- **`Activation/DefaultActivationHandler.cs`** — Replaced `typeof(DecodeViewModel).FullName!` with the string literal `"barcodrod.io.ViewModels.DecodeViewModel"`. Removed `barcodrod.io.ViewModels` using.
+- **`Activation/DefaultActivationHandler.cs`** ï¿½ Replaced `typeof(DecodeViewModel).FullName!` with the string literal `"barcodrod.io.ViewModels.DecodeViewModel"`. Removed `barcodrod.io.ViewModels` using.
 
-- **`Services/LocalSettingsService.cs`** — Updated using statements from `barcodrod.io.Core.Contracts.Services` and `barcodrod.io.Core.Helpers` to `barcodrod.io.Contracts.Services` and `barcodrod.io.Helpers`.
+- **`Services/LocalSettingsService.cs`** ï¿½ Updated using statements from `barcodrod.io.Core.Contracts.Services` and `barcodrod.io.Core.Helpers` to `barcodrod.io.Contracts.Services` and `barcodrod.io.Helpers`.
 
-- **`Views/EncodePage.xaml.cs`** — Removed `using barcodrod.io.ViewModels` and the unused `public EncodeViewModel ViewModel { get; }` property.
+- **`Views/EncodePage.xaml.cs`** ï¿½ Removed `using barcodrod.io.ViewModels` and the unused `public EncodeViewModel ViewModel { get; }` property.
 
-- **`Views/HistoryPage.xaml.cs`** — Removed `using barcodrod.io.ViewModels` and the discarded `App.GetService<HistoryViewModel>()` call.
+- **`Views/HistoryPage.xaml.cs`** ï¿½ Removed `using barcodrod.io.ViewModels` and the discarded `App.GetService<HistoryViewModel>()` call.
 
-- **`barcodrod.io.csproj`** — Removed `<ProjectReference>` to `barcodrod.io.Core`. Added direct `<PackageReference>` for `Newtonsoft.Json` 13.0.4 (previously transitive via Core).
+- **`barcodrod.io.csproj`** ï¿½ Removed `<ProjectReference>` to `barcodrod.io.Core`. Added direct `<PackageReference>` for `Newtonsoft.Json` 13.0.4 (previously transitive via Core).
 
-### Added — Pin on Top Feature
+### Added ï¿½ Pin on Top Feature
 
-- **`Views/ShellPage.xaml`** — Added a `NavigationViewItem` in `NavigationView.FooterMenuItems` (above the Settings gear) with a pin icon (`&#xE718;`) that toggles always-on-top.
+- **`Views/ShellPage.xaml`** ï¿½ Added a `NavigationViewItem` in `NavigationView.FooterMenuItems` (above the Settings gear) with a pin icon (`&#xE718;`) that toggles always-on-top.
 
-- **`Views/ShellPage.xaml.cs`** — Added `PinButton_Click` handler that toggles `App.MainWindow.IsAlwaysOnTop` (WinUIEx), swaps the icon glyph between pin/unpin states, and updates the tooltip.
+- **`Views/ShellPage.xaml.cs`** ï¿½ Added `PinButton_Click` handler that toggles `App.MainWindow.IsAlwaysOnTop` (WinUIEx), swaps the icon glyph between pin/unpin states, and updates the tooltip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v2.1
 
 ### Added — CI/CD code signing (SignPath) for the MSI
 
@@ -56,6 +56,20 @@
 - **Unhandled exceptions are now logged** — `App.App_UnhandledException` writes to
   `%LOCALAPPDATA%\barcodrod.io\crash.log` instead of silently swallowing exceptions (`e.Handled` is
   still set to keep prior behaviour). This surfaced the unpackaged startup failures above.
+
+### Bug Fixes — Webcam
+
+- **Fixed the webcam button being disabled on launch (#36)** — On the default (Windows Camera /
+  MediaCapture) backend the camera source dropdown was populated but never given a selection, and
+  the webcam button is only enabled in response to a selection change. `LoadWebcamSettings` was
+  meant to restore the previous source, but it returned early when `settings.json` was missing or
+  empty, skipping the "select the first source" fallback at the end of the method. On a fresh
+  install the button therefore stayed greyed out. Source restoration is now separated from the
+  fallback (`TryRestoreSavedWebcamSourceAsync`), so a default source is always selected when nothing
+  can be restored — including missing, empty, or malformed settings, or a saved camera that is no
+  longer present. This restores the behaviour added in #27.
+
+## v2.0
 
 ### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,16 @@ Method 1: Directly from the Microsoft Store [HERE](https://www.microsoft.com/sto
 
 Method 2: Downloading and installing the MSIX package directly from the latest GitHub release [HERE](https://github.com/MarkHopper24/barcodrod.io/releases/latest) 
 
-Method 3: From Windows Package Manager using winget via command line
+Method 3: Downloading and running the standalone **MSI installer** from the latest GitHub release [HERE](https://github.com/MarkHopper24/barcodrod.io/releases/latest). This is a classic, fully offline installer (x64 and arm64) that does not require the Microsoft Store, winget, or an internet connection. It is code-signed via the [SignPath Foundation](https://signpath.org) (see the Code signing policy below) and is the recommended option for offline or locked-down environments.
+
+Method 4: From Windows Package Manager using winget via command line
 ```
 winget install --name barcodrod.io
 ```
 
-For now, barcodrod.io requires an internet connection on installation  for license acquisition through the Microsoft Store (this includes the build hosted in this repository). After first installation, it can be used fully offline. It is a planned roadmap item to implement an fully offline installation method.
+The Microsoft Store and MSIX install paths (Methods 1, 2 and 4) require an internet connection on first installation for license acquisition through the Microsoft Store; after the first launch the app can be used fully offline. The standalone MSI installer (Method 3) does not have this requirement and installs completely offline.
 
-Method 4: Building the solution on your own in Visual Studio using the provided source code (this method does not require a network connection).
+Method 5: Building the solution on your own in Visual Studio using the provided source code (this method does not require a network connection).
 
 ## Usage
 Includes support for the following barcode formats:
@@ -107,6 +109,27 @@ This software would not have been possible without the the following tools, reso
 - [Template Studio for WinUI](https://marketplace.visualstudio.com/items?itemName=TemplateStudio.TemplateStudioForWinUICs)
 - [Windows Camera](https://apps.microsoft.com/store/detail/windows-camera/9WZDNCRFJBBG?) and [Snipping Tool](https://apps.microsoft.com/store/detail/snipping-tool/9MZ95KL8MR0L)
 - AForge.NET (DirectShow Library)
+
+## Code signing policy
+
+Free code signing for the standalone MSI installer published in this repository's
+[GitHub Releases](https://github.com/MarkHopper24/barcodrod.io/releases) is provided by
+[SignPath.io](https://about.signpath.io), with a certificate issued by the
+[SignPath Foundation](https://signpath.org).
+
+**Team roles**
+- **Authors & reviewers:** project maintainers — see the repository
+  [contributors](https://github.com/MarkHopper24/barcodrod.io/graphs/contributors).
+- **Approvers:** repository owner ([@MarkHopper24](https://github.com/MarkHopper24)). Every release
+  signing request is reviewed and approved manually.
+
+**Privacy**
+barcodrod.io processes barcodes and QR codes locally on your PC. This program will not transfer any
+information to other networked systems unless specifically requested by the user or the person
+installing or operating it. See the [Privacy Notes](#privacy-notes) above.
+
+> The Microsoft Store build is signed by Microsoft through the Store. The MSI installer in GitHub
+> Releases is signed via the SignPath Foundation and installs fully offline.
 
 ## License
 [Apache 2.0](https://github.com/MarkHopper24/barcodrod.io/blob/public/LICENSE.txt)

--- a/barcodrod.io/Activation/DefaultActivationHandler.cs
+++ b/barcodrod.io/Activation/DefaultActivationHandler.cs
@@ -1,4 +1,5 @@
-﻿using barcodrod.io.Contracts.Services;
+using barcodrod.io.Helpers;
+using barcodrod.io.Contracts.Services;
 
 using Microsoft.UI.Xaml;
 using Newtonsoft.Json.Linq;
@@ -33,7 +34,7 @@ public class DefaultActivationHandler : ActivationHandler<Microsoft.UI.Xaml.Laun
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
             if (!File.Exists(settingsFilePath))
                 return "barcodrod.io.ViewModels.DecodeViewModel";

--- a/barcodrod.io/App.xaml.cs
+++ b/barcodrod.io/App.xaml.cs
@@ -71,8 +71,18 @@ public partial class App : Application
 
     private void App_UnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs e)
     {
-        // TODO: Log and handle exceptions as appropriate.
-        // https://docs.microsoft.com/windows/windows-app-sdk/api/winrt/microsoft.ui.xaml.application.unhandledexception.
+        try
+        {
+            var dir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "barcodrod.io");
+            Directory.CreateDirectory(dir);
+            File.AppendAllText(Path.Combine(dir, "crash.log"),
+                $"{DateTime.Now:o}\t{e.Message}\n{e.Exception}\n\n");
+        }
+        catch
+        {
+            // Never let crash logging itself crash the app.
+        }
+
         // call e.Handled = true to prevent the app from closing when this method returns.
         e.Handled = true;
     }
@@ -92,6 +102,39 @@ public partial class App : Application
             }
         }
 
+        // Classic (unpackaged / MSI) file association passes the file as a command-line argument
+        // rather than via the File activation contract used by the packaged (MSIX) build.
+        var commandLineFilePath = GetFilePathFromCommandLine();
+        if (!string.IsNullOrWhiteSpace(commandLineFilePath))
+        {
+            await GetService<IActivationService>().ActivateAsync(commandLineFilePath);
+            return;
+        }
+
         await GetService<IActivationService>().ActivateAsync(args);
+    }
+
+    private static string? GetFilePathFromCommandLine()
+    {
+        var commandLineArgs = Environment.GetCommandLineArgs();
+
+        // Index 0 is the executable path. Skip Windows App SDK activation tokens (e.g. the
+        // "----AppNotificationActivated:" argument used by the toast COM activator) and return
+        // the first argument that resolves to an existing file.
+        for (var i = 1; i < commandLineArgs.Length; i++)
+        {
+            var arg = commandLineArgs[i];
+            if (string.IsNullOrWhiteSpace(arg) || arg.StartsWith("----"))
+            {
+                continue;
+            }
+
+            if (File.Exists(arg))
+            {
+                return arg;
+            }
+        }
+
+        return null;
     }
 }

--- a/barcodrod.io/Helpers/AppPaths.cs
+++ b/barcodrod.io/Helpers/AppPaths.cs
@@ -1,0 +1,53 @@
+﻿using System.IO;
+
+using Windows.Storage;
+
+namespace barcodrod.io.Helpers;
+
+/// <summary>
+/// Resolves the per-user local data folder in a way that works both when the app runs
+/// packaged (MSIX, where <see cref="ApplicationData"/> is available) and unpackaged
+/// (classic MSI / portable, where <see cref="ApplicationData.Current"/> throws because
+/// the process has no package identity).
+/// </summary>
+public static class AppPaths
+{
+    private static StorageFolder? _localFolder;
+
+    /// <summary>
+    /// Absolute path to the folder where the app stores its settings and logs.
+    /// The folder is created if it does not yet exist.
+    /// </summary>
+    public static string LocalDataFolder
+    {
+        get
+        {
+            if (RuntimeHelper.IsMSIX)
+            {
+                return ApplicationData.Current.LocalFolder.Path;
+            }
+
+            var path = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "barcodrod.io");
+            Directory.CreateDirectory(path);
+            return path;
+        }
+    }
+
+    /// <summary>
+    /// Returns the local data folder as a <see cref="StorageFolder"/>, working in both packaged
+    /// and unpackaged modes. Use this anywhere the code previously used
+    /// <c>ApplicationData.Current.LocalFolder</c> so it keeps functioning when the app is
+    /// installed via the classic (unpackaged) MSI.
+    /// </summary>
+    public static async Task<StorageFolder> GetLocalFolderAsync()
+    {
+        if (RuntimeHelper.IsMSIX)
+        {
+            return ApplicationData.Current.LocalFolder;
+        }
+
+        return _localFolder ??= await StorageFolder.GetFolderFromPathAsync(LocalDataFolder);
+    }
+}

--- a/barcodrod.io/MainWindow.xaml.cs
+++ b/barcodrod.io/MainWindow.xaml.cs
@@ -2,16 +2,15 @@
 using Microsoft.UI.Xaml.Media;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Windows.Storage;
 
 namespace barcodrod.io;
 
 public sealed partial class MainWindow : WindowEx
 {
-    private StorageFolder? localFolder;
+    private string? localFolderPath;
     private string? settingsFilePath;
     private bool SettingsLoaded = false;
-    private StorageFile? currentLogPath;
+    private string? currentLogPath;
 
     public MainWindow()
     {
@@ -28,9 +27,9 @@ public sealed partial class MainWindow : WindowEx
         {
             await InitializeLog();
             Log("Initalizing logging.");
-            localFolder = ApplicationData.Current.LocalFolder;
-            Log("localAppFolder: " + localFolder.Path);
-            settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
+            localFolderPath = AppPaths.LocalDataFolder;
+            Log("localAppFolder: " + localFolderPath);
+            settingsFilePath = Path.Combine(localFolderPath, "settings.json");
             //barcodrod.io defaults
             var historyEnabled = true;
             var backdropIndex = 0;
@@ -39,8 +38,6 @@ public sealed partial class MainWindow : WindowEx
             if (File.Exists(settingsFilePath) == false)
             {
                 Log("Settings file not found. Creating with default values.");
-                var settingsFile = await localFolder.CreateFileAsync("settings.json",
-                    CreationCollisionOption.OpenIfExists);
                 var data = new
                 {
                     HistoryEnabled = historyEnabled,
@@ -126,10 +123,8 @@ public sealed partial class MainWindow : WindowEx
             Log("Settings file not found. Creating with default values.");
 
             SettingsLoaded = false;
-            localFolder = ApplicationData.Current.LocalFolder;
-            settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
-            var settingsFile = await localFolder.CreateFileAsync("settings.json",
-                CreationCollisionOption.ReplaceExisting);
+            localFolderPath = AppPaths.LocalDataFolder;
+            settingsFilePath = Path.Combine(localFolderPath, "settings.json");
             Log("Settings file created.");
             var data = new
             {
@@ -138,7 +133,6 @@ public sealed partial class MainWindow : WindowEx
             };
 
             var json = JsonConvert.SerializeObject(data, Formatting.Indented);
-            settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
             File.WriteAllText(settingsFilePath, json);
             Log("Default values written.");
 
@@ -178,27 +172,23 @@ public sealed partial class MainWindow : WindowEx
     {
         try
         {
-            localFolder = ApplicationData.Current.LocalFolder;
+            localFolderPath = AppPaths.LocalDataFolder;
 
             //create log file based on current date and time
             var logFileName = "log.txt";
+            var logFullPath = Path.Combine(localFolderPath, logFileName);
 
-            //get the size of log.txt if it exists
-            ulong logSize = 0;
-            if (File.Exists(Path.Combine(localFolder.Path, logFileName)))
+            //if the log file is greater than 30mb, start a new log file
+            if (File.Exists(logFullPath))
             {
-                var logFile = await localFolder.GetFileAsync(logFileName);
-                var logProperties = await logFile.GetBasicPropertiesAsync();
-                logSize = logProperties.Size;
+                var logSize = new FileInfo(logFullPath).Length;
+                if (logSize > 30000000)
+                {
+                    File.WriteAllText(logFullPath, string.Empty);
+                }
             }
 
-            //if the log file is greater than 30mb, create a new log file
-            if (logSize > 30000000)
-                currentLogPath = await localFolder.CreateFileAsync(logFileName,
-                    CreationCollisionOption.ReplaceExisting);
-            else
-                currentLogPath = await localFolder.CreateFileAsync(logFileName,
-                    CreationCollisionOption.OpenIfExists);
+            currentLogPath = logFullPath;
 
             return;
         }
@@ -215,7 +205,7 @@ public sealed partial class MainWindow : WindowEx
             if (currentLogPath != null)
             {
                 var logMessage = DateTime.Now.ToString() + ": " + message + "\n";
-                File.AppendAllText(currentLogPath.Path, logMessage);
+                File.AppendAllText(currentLogPath, logMessage);
             }
         }
         catch

--- a/barcodrod.io/Package.appxmanifest
+++ b/barcodrod.io/Package.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="53383MarkHopper.570136E6C1E54"
     Publisher="CN=ADA72B16-B88A-4477-94E0-44F1442A4EAE"
-    Version="2.0.0.0" />
+    Version="2.1.0.0" />
 
   <Properties>
     <DisplayName>barcodrod.io</DisplayName>

--- a/barcodrod.io/Views/DecodePage.xaml.cs
+++ b/barcodrod.io/Views/DecodePage.xaml.cs
@@ -1,3 +1,4 @@
+using barcodrod.io.Helpers;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
@@ -61,6 +62,7 @@ public partial class DecodePage : Page
     private FilterInfoCollection? _directShowVideoDevices;
     private VideoCaptureDevice? _directShowVideoDevice;
     private int _isProcessingDirectShowFrame;
+    private Task? _cameraInitializationTask;
 
     private static readonly HashSet<string> SupportedImageExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -76,7 +78,7 @@ public partial class DecodePage : Page
         InitializeLog();
         LoadPasteToDecodeSetting();
 
-        _ = InitializeCameraBackendAsync();
+        _cameraInitializationTask = InitializeCameraBackendAsync();
 
         reader.Options.TryHarder = true;
         reader.Options.TryInverted = true;
@@ -120,7 +122,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
             if (!File.Exists(settingsFilePath))
             {
@@ -148,7 +150,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            localFolder = ApplicationData.Current.LocalFolder;
+            localFolder = (await AppPaths.GetLocalFolderAsync());
 
             //create log file based on current date and time
             var logFileName = "log.txt";
@@ -250,7 +252,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             if (!File.Exists(settingsFilePath)) return;
@@ -392,7 +394,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             if (!File.Exists(settingsFilePath)) return;
@@ -421,7 +423,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             if (!File.Exists(settingsFilePath)) return;
@@ -488,6 +490,10 @@ public partial class DecodePage : Page
     protected override async void OnNavigatedTo(NavigationEventArgs e)
     {
         base.OnNavigatedTo(e);
+        if (_cameraInitializationTask != null)
+        {
+            try { await _cameraInitializationTask; } catch { }
+        }
         await LoadWebcamSettings();
 
         if (_hasProcessedLaunchArgument)
@@ -531,7 +537,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             JObject settings;
@@ -546,6 +552,7 @@ public partial class DecodePage : Page
             }
 
             settings["WebcamSourceIndex"] = comboBox1.SelectedIndex;
+            settings["WebcamSourceName"] = comboBox1.SelectedItem?.ToString();
             File.WriteAllText(settingsFilePath, settings.ToString(Formatting.Indented));
         }
         catch
@@ -557,7 +564,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             if (!File.Exists(settingsFilePath)) return;
@@ -566,14 +573,35 @@ public partial class DecodePage : Page
             if (string.IsNullOrEmpty(json)) return;
 
             var settings = JObject.Parse(json);
-            var savedIndex = settings["WebcamSourceIndex"];
-            if (savedIndex == null) return;
 
-            var index = savedIndex.Value<int>();
-            if (index >= 0 && index < comboBox1.Items.Count)
+            if (comboBox1.Items.Count == 0) return;
+
+            var savedName = settings["WebcamSourceName"]?.Value<string>();
+            if (!string.IsNullOrEmpty(savedName))
             {
-                comboBox1.SelectedIndex = index;
+                for (var i = 0; i < comboBox1.Items.Count; i++)
+                {
+                    if (string.Equals(comboBox1.Items[i]?.ToString(), savedName, StringComparison.Ordinal))
+                    {
+                        comboBox1.SelectedIndex = i;
+                        return;
+                    }
+                }
             }
+
+            var savedIndex = settings["WebcamSourceIndex"];
+            if (savedIndex != null)
+            {
+                var index = savedIndex.Value<int>();
+                if (index >= 0 && index < comboBox1.Items.Count)
+                {
+                    comboBox1.SelectedIndex = index;
+                    return;
+                }
+            }
+
+            if (comboBox1.SelectedIndex < 0)
+                comboBox1.SelectedIndex = 0;
         }
         catch
         {
@@ -1283,7 +1311,7 @@ public partial class DecodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             //get the history folder
@@ -1327,7 +1355,7 @@ public partial class DecodePage : Page
             else
             {
                 //create folder called history if it doesn't exist
-                var localFolder = ApplicationData.Current.LocalFolder;
+                var localFolder = (await AppPaths.GetLocalFolderAsync());
                 var historyFolder =
                     await localFolder.CreateFolderAsync("History", CreationCollisionOption.OpenIfExists);
 
@@ -1791,7 +1819,7 @@ public partial class DecodePage : Page
     {
         if (lastDecoded != null)
         {
-            var file = await ApplicationData.Current.LocalFolder.CreateFileAsync("temp.png",
+            var file = await (await AppPaths.GetLocalFolderAsync()).CreateFileAsync("temp.png",
                 CreationCollisionOption.ReplaceExisting);
             lastDecoded.Save(file.Path, ImageFormat.Png);
             var dataPackage = new DataPackage();
@@ -1835,11 +1863,11 @@ public partial class DecodePage : Page
 
         InitializeWithWindow.Initialize(picker, hwnd);
         var path = await picker.PickSaveFileAsync();
-        var tempCSVExists = await ApplicationData.Current.LocalFolder.TryGetItemAsync("temp.csv");
+        var tempCSVExists = await (await AppPaths.GetLocalFolderAsync()).TryGetItemAsync("temp.csv");
 
         if (path != null && tempCSVExists != null)
         {
-            var csv = await ApplicationData.Current.LocalFolder.GetFileAsync("temp.csv");
+            var csv = await (await AppPaths.GetLocalFolderAsync()).GetFileAsync("temp.csv");
             await csv.CopyAndReplaceAsync(path);
             await csv.DeleteAsync();
 
@@ -1977,7 +2005,7 @@ public partial class DecodePage : Page
         var result = string.Empty;
         var ScanResult = string.Empty;
 
-        var csv = await ApplicationData.Current.LocalFolder.CreateFileAsync("temp.csv",
+        var csv = await (await AppPaths.GetLocalFolderAsync()).CreateFileAsync("temp.csv",
             CreationCollisionOption.ReplaceExisting);
         var csvPath = csv.Path;
 
@@ -2090,11 +2118,11 @@ public partial class DecodePage : Page
         ImageFolderButton.IsEnabled = true;
 
 
-        var tempCSVExists = await ApplicationData.Current.LocalFolder.TryGetItemAsync("temp.csv");
+        var tempCSVExists = await (await AppPaths.GetLocalFolderAsync()).TryGetItemAsync("temp.csv");
 
         if (tempCSVExists != null)
         {
-            var csv = await ApplicationData.Current.LocalFolder.GetFileAsync("temp.csv");
+            var csv = await (await AppPaths.GetLocalFolderAsync()).GetFileAsync("temp.csv");
             await csv.DeleteAsync();
         }
     }

--- a/barcodrod.io/Views/DecodePage.xaml.cs
+++ b/barcodrod.io/Views/DecodePage.xaml.cs
@@ -560,21 +560,50 @@ public partial class DecodePage : Page
         }
     }
 
+    /// <summary>
+    /// Restores the previously selected webcam source, falling back to the first available source
+    /// when nothing can be restored.
+    /// </summary>
+    /// <remarks>
+    /// Selecting a source raises <see cref="DirectShowSourceChanged"/>, which is what enables the
+    /// webcam button. Without a guaranteed selection the button stays disabled after launch on the
+    /// default (MediaCapture) backend — that is issue #36, which regressed the behaviour added in
+    /// #27. The fallback must therefore run on every failure path: missing settings file, empty or
+    /// malformed JSON, or a saved source that no longer exists.
+    /// </remarks>
     private async Task LoadWebcamSettings()
+    {
+        try
+        {
+            if (comboBox1.Items.Count == 0) return;
+
+            if (await TryRestoreSavedWebcamSourceAsync()) return;
+
+            if (comboBox1.SelectedIndex < 0)
+                comboBox1.SelectedIndex = 0;
+        }
+        catch
+        {
+        }
+    }
+
+    /// <summary>
+    /// Attempts to reselect the webcam source recorded in settings.json.
+    /// </summary>
+    /// <returns><c>true</c> if a saved source was found and selected; otherwise <c>false</c>.</returns>
+    private async Task<bool> TryRestoreSavedWebcamSourceAsync()
     {
         try
         {
             var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
-            if (!File.Exists(settingsFilePath)) return;
+            if (!File.Exists(settingsFilePath)) return false;
 
             var json = await File.ReadAllTextAsync(settingsFilePath);
-            if (string.IsNullOrEmpty(json)) return;
+            if (string.IsNullOrWhiteSpace(json)) return false;
 
             var settings = JObject.Parse(json);
-
-            if (comboBox1.Items.Count == 0) return;
 
             var savedName = settings["WebcamSourceName"]?.Value<string>();
             if (!string.IsNullOrEmpty(savedName))
@@ -584,7 +613,7 @@ public partial class DecodePage : Page
                     if (string.Equals(comboBox1.Items[i]?.ToString(), savedName, StringComparison.Ordinal))
                     {
                         comboBox1.SelectedIndex = i;
-                        return;
+                        return true;
                     }
                 }
             }
@@ -596,16 +625,16 @@ public partial class DecodePage : Page
                 if (index >= 0 && index < comboBox1.Items.Count)
                 {
                     comboBox1.SelectedIndex = index;
-                    return;
+                    return true;
                 }
             }
-
-            if (comboBox1.SelectedIndex < 0)
-                comboBox1.SelectedIndex = 0;
         }
-        catch
+        catch (Exception ex)
         {
+            Log("Could not restore the saved webcam source: " + ex.Message);
         }
+
+        return false;
     }
 
     private async void DirectShowSourceChanged(object sender, RoutedEventArgs e)

--- a/barcodrod.io/Views/EncodePage.xaml.cs
+++ b/barcodrod.io/Views/EncodePage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml;
+using barcodrod.io.Helpers;
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Controls.Primitives;
 using Microsoft.UI.Xaml.Media.Imaging;
@@ -74,7 +75,7 @@ public sealed partial class EncodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             JObject settings;
@@ -105,7 +106,7 @@ public sealed partial class EncodePage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             if (!File.Exists(settingsFilePath)) return;
@@ -165,7 +166,7 @@ public sealed partial class EncodePage : Page
     {
         if (lastEncoded != null)
         {
-            var file = await ApplicationData.Current.LocalFolder.CreateFileAsync("temp.png",
+            var file = await (await AppPaths.GetLocalFolderAsync()).CreateFileAsync("temp.png",
                 CreationCollisionOption.ReplaceExisting);
             lastEncoded.Save(file.Path, ImageFormat.Png);
             var dataPackage = new Windows.ApplicationModel.DataTransfer.DataPackage();
@@ -548,7 +549,7 @@ public sealed partial class EncodePage : Page
 
     private async Task<bool> IsHistoryEnabled()
     {
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         //get the history folder
@@ -576,7 +577,7 @@ public sealed partial class EncodePage : Page
         else
         {
             //create folder called history if it doesn't exist
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var historyFolder = await localFolder.CreateFolderAsync("History", CreationCollisionOption.OpenIfExists);
 
             var files = await historyFolder.GetFilesAsync();

--- a/barcodrod.io/Views/HistoryPage.xaml.cs
+++ b/barcodrod.io/Views/HistoryPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI;
+using barcodrod.io.Helpers;
+using Microsoft.UI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
@@ -48,7 +49,7 @@ public sealed partial class HistoryPage : Page
         var imageFolder = await savePath.CreateFolderAsync("Barcodes" + "." + timestamp);
         var textFolder = await savePath.CreateFolderAsync("Text" + "." + timestamp);
 
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var historyFolder = await localFolder.GetFolderAsync("History");
         if (historyFolder != null)
         {
@@ -123,7 +124,7 @@ public sealed partial class HistoryPage : Page
         var imageFolder = await savePath.CreateFolderAsync("Barcodes" + "." + timestamp);
 
 
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var historyFolder = await localFolder.GetFolderAsync("History");
         if (historyFolder != null)
         {
@@ -183,7 +184,7 @@ public sealed partial class HistoryPage : Page
         //create two folders, one for the images and one for the text files
         var textFolder = await savePath.CreateFolderAsync("Text" + "." + timestamp);
 
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var historyFolder = await localFolder.GetFolderAsync("History");
         if (historyFolder != null)
         {
@@ -247,7 +248,7 @@ public sealed partial class HistoryPage : Page
 
         if (selectedItems.Count == 0) return;
 
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var historyFolder = await localFolder.GetFolderAsync("History");
         if (historyFolder != null)
         {
@@ -349,7 +350,7 @@ public sealed partial class HistoryPage : Page
 
         if (isHistoryEnabled == true)
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var historyFolder = await localFolder.GetFolderAsync("History");
 
             if (historyFolder != null)
@@ -577,7 +578,7 @@ public sealed partial class HistoryPage : Page
 
     private async Task<bool> IsHistoryEnabled()
     {
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
         try
         {
@@ -604,7 +605,7 @@ public sealed partial class HistoryPage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
             if (!File.Exists(settingsFilePath))
             {
@@ -642,7 +643,7 @@ public sealed partial class HistoryPage : Page
     {
         try
         {
-            var localFolder = ApplicationData.Current.LocalFolder;
+            var localFolder = (await AppPaths.GetLocalFolderAsync());
             var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             JObject settings;

--- a/barcodrod.io/Views/SettingsPage.xaml.cs
+++ b/barcodrod.io/Views/SettingsPage.xaml.cs
@@ -1,4 +1,4 @@
-﻿using barcodrod.io.Helpers;
+using barcodrod.io.Helpers;
 using barcodrod.io.ViewModels;
 using Microsoft.Windows.AppLifecycle;
 using Microsoft.UI.Xaml;
@@ -76,7 +76,7 @@ public sealed partial class SettingsPage : Page
     {
         try
         {
-            localFolder = ApplicationData.Current.LocalFolder;
+            localFolder = (await AppPaths.GetLocalFolderAsync());
             settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
             //barcodrod.io defaults
@@ -160,7 +160,7 @@ public sealed partial class SettingsPage : Page
         catch
         {
             SettingsLoaded = false;
-            localFolder = ApplicationData.Current.LocalFolder;
+            localFolder = (await AppPaths.GetLocalFolderAsync());
             settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
             var settingsFile = await localFolder.CreateFileAsync("settings.json",
                 CreationCollisionOption.ReplaceExisting);
@@ -184,7 +184,7 @@ public sealed partial class SettingsPage : Page
 
     private async void EnableHistory(object sender, RoutedEventArgs e)
     {
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         //read HistoryEnabled from settings.json
@@ -204,7 +204,7 @@ public sealed partial class SettingsPage : Page
     {
         //get the history folder
 
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         //get the history folder
@@ -255,7 +255,7 @@ public sealed partial class SettingsPage : Page
 
     private async void UpdateBackDrop(object sender, SelectionChangedEventArgs e)
     {
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var backdropIndex = Backdrops.SelectedIndex;
@@ -316,7 +316,7 @@ public sealed partial class SettingsPage : Page
     private async void EnableAutoCopy(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -328,7 +328,7 @@ public sealed partial class SettingsPage : Page
     private async void DisableAutoCopy(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -340,7 +340,7 @@ public sealed partial class SettingsPage : Page
     private async void EnableAutoOpenUrl(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -352,7 +352,7 @@ public sealed partial class SettingsPage : Page
     private async void DisableAutoOpenUrl(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -364,7 +364,7 @@ public sealed partial class SettingsPage : Page
     private async void EnablePasteToDecode(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -376,7 +376,7 @@ public sealed partial class SettingsPage : Page
     private async void DisablePasteToDecode(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -388,7 +388,7 @@ public sealed partial class SettingsPage : Page
     private async void EnableAutoEncodeOnPaste(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -400,7 +400,7 @@ public sealed partial class SettingsPage : Page
     private async void DisableAutoEncodeOnPaste(object sender, RoutedEventArgs e)
     {
         if (!SettingsLoaded) return;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -413,7 +413,7 @@ public sealed partial class SettingsPage : Page
     {
         if (!SettingsLoaded) return;
 
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         var jsonSettings = await File.ReadAllTextAsync(settingsFilePath);
@@ -440,7 +440,7 @@ public sealed partial class SettingsPage : Page
             return;
 
         var requestedValue = UseLegacyDirectShow.IsChecked == true;
-        var localFolder = ApplicationData.Current.LocalFolder;
+        var localFolder = (await AppPaths.GetLocalFolderAsync());
         var settingsFilePath = Path.Combine(localFolder.Path, "settings.json");
 
         JObject settings;

--- a/barcodrod.io/barcodrod.io.csproj
+++ b/barcodrod.io/barcodrod.io.csproj
@@ -20,11 +20,12 @@
     <GenerateTestArtifacts>False</GenerateTestArtifacts>
     <AppxBundle>Always</AppxBundle>
     <AppxBundlePlatforms>x64</AppxBundlePlatforms>
-    <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
     <BuildAppxUploadPackageForUap>false</BuildAppxUploadPackageForUap>
     <GenerateTemporaryStoreCertificate>false</GenerateTemporaryStoreCertificate>
     <UserSecretsId>b509cab9-7bac-4a2a-b212-4c9b770155a3</UserSecretsId>
-    <AppxPackageDir>D:\barcodrod.io_builds\</AppxPackageDir>
+    <!-- Output packages to a repo-relative folder by default so CI and other contributors don't
+         depend on a machine-specific path. CI overrides this with /p:AppxPackageDir on the command line. -->
+    <AppxPackageDir Condition="'$(AppxPackageDir)' == ''">$(MSBuildThisFileDirectory)AppPackages\</AppxPackageDir>
     <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
     <ApplicationIcon>Assets\WindowIcon.ico</ApplicationIcon>
     <AppxPackageSigningEnabled>False</AppxPackageSigningEnabled>

--- a/installer/barcodrod.io.wxs
+++ b/installer/barcodrod.io.wxs
@@ -28,8 +28,16 @@
         Manufacturer="Mark Hopper"
         Description="barcodrod.io $(Version) installer" />
 
-    <!-- Clean in-place upgrades; block downgrades. -->
-    <MajorUpgrade DowngradeErrorMessage="A newer version of barcodrod.io is already installed." />
+    <!--
+      Clean in-place upgrades; block downgrades.
+      AllowSameVersionUpgrades is required because x64 and arm64 get different ProductCodes while
+      sharing this UpgradeCode and version. Without it, Windows Installer treats them as unrelated
+      products and both install into the same folder (and a same-version rebuild would too).
+      It makes the upgrade version range max-inclusive, which raises ICE61 under `wix msi validate`;
+      `wix build` (WiX 5) does not run ICE validation, so no suppression is needed here.
+    -->
+    <MajorUpgrade AllowSameVersionUpgrades="yes"
+                  DowngradeErrorMessage="A newer version of barcodrod.io is already installed." />
 
     <MediaTemplate EmbedCab="yes" />
 
@@ -70,7 +78,10 @@
           <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{DD6D181A-17B6-4A3A-9E66-B9399E0F1184}" />
         </Shortcut>
         <RemoveFolder Id="RemoveAppShortcutFolder" On="uninstall" />
-        <RegistryValue Root="HKCU"
+        <!-- HKLM, not HKCU: this is a perMachine package, so a per-user keypath would make the
+             component's installed state user-specific and break repair/uninstall from another
+             account (ICE38/ICE43). -->
+        <RegistryValue Root="HKLM"
                        Key="Software\barcodrod.io\Installed"
                        Name="StartMenuShortcut"
                        Type="integer"

--- a/installer/barcodrod.io.wxs
+++ b/installer/barcodrod.io.wxs
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  barcodrod.io classic (unpackaged) MSI installer — WiX v5.
+  Maintainable by design:
+    * Files are auto-harvested from the publish output at build time via <Files Include="...\**">.
+      There is NO hand-maintained file list, so new/removed files are picked up automatically.
+    * Per-machine install into Program Files, Start Menu shortcut with an explicit AppUserModelID
+      (required for unpackaged WinApp SDK toast notifications), and automatic uninstall/ARP entry.
+
+  Build (values supplied by build-msi.ps1 / CI):
+    wix build installer\barcodrod.io.wxs -arch x64 ^
+      -d Version=<x.y.z.0> -d PublishDir=<path to publish output> -o <out>.msi
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+
+  <?ifndef Version ?><?define Version = "0.0.0.0" ?><?endif?>
+  <?ifndef PublishDir ?><?define PublishDir = "..\artifacts\publish\x64" ?><?endif?>
+
+  <Package
+      Name="barcodrod.io"
+      Manufacturer="Mark Hopper"
+      Version="$(Version)"
+      UpgradeCode="ADE87DB3-A892-4FF5-AF98-FCE2D5372793"
+      Scope="perMachine"
+      Compressed="yes">
+
+    <SummaryInformation
+        Manufacturer="Mark Hopper"
+        Description="barcodrod.io $(Version) installer" />
+
+    <!-- Clean in-place upgrades; block downgrades. -->
+    <MajorUpgrade DowngradeErrorMessage="A newer version of barcodrod.io is already installed." />
+
+    <MediaTemplate EmbedCab="yes" />
+
+    <!-- Application icon for Add/Remove Programs, sourced from the published exe. -->
+    <Icon Id="AppIcon" SourceFile="$(PublishDir)\barcodrod.io.exe" />
+    <Property Id="ARPPRODUCTICON" Value="AppIcon" />
+    <Property Id="ARPURLINFOABOUT" Value="https://barcodrod.io" />
+
+    <!-- Install layout -->
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="barcodrod.io" />
+    </StandardDirectory>
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="AppShortcutFolder" Name="barcodrod.io" />
+    </StandardDirectory>
+
+    <!--
+      Auto-harvest every published file into INSTALLFOLDER.
+      Excludes the debug symbols (.pdb) which are not needed at runtime.
+    -->
+    <ComponentGroup Id="PublishedFiles" Directory="INSTALLFOLDER">
+      <Files Include="$(PublishDir)\**">
+        <Exclude Files="$(PublishDir)\**\*.pdb" />
+      </Files>
+    </ComponentGroup>
+
+    <!-- Start Menu shortcut + uninstall registration. -->
+    <DirectoryRef Id="AppShortcutFolder">
+      <Component Id="ApplicationShortcut" Guid="*">
+        <Shortcut Id="AppStartMenuShortcut"
+                  Name="barcodrod.io"
+                  Description="A free, modern barcode and QR code toolkit for Windows."
+                  Target="[INSTALLFOLDER]barcodrod.io.exe"
+                  WorkingDirectory="INSTALLFOLDER">
+          <!-- Stable AppUserModelID + toast activator CLSID so unpackaged toast notifications
+               resolve to this shortcut, 1:1 with the MSIX manifest's toastNotificationActivation. -->
+          <ShortcutProperty Key="System.AppUserModel.ID" Value="barcodrod.io" />
+          <ShortcutProperty Key="System.AppUserModel.ToastActivatorCLSID" Value="{DD6D181A-17B6-4A3A-9E66-B9399E0F1184}" />
+        </Shortcut>
+        <RemoveFolder Id="RemoveAppShortcutFolder" On="uninstall" />
+        <RegistryValue Root="HKCU"
+                       Key="Software\barcodrod.io\Installed"
+                       Name="StartMenuShortcut"
+                       Type="integer"
+                       Value="1"
+                       KeyPath="yes" />
+      </Component>
+    </DirectoryRef>
+
+    <!--
+      File type associations — 1:1 with the MSIX manifest's "image" fileTypeAssociation.
+      Registers a ProgID and advertises barcodrod.io in the "Open with" list for each image type
+      (non-destructive: it does not seize the existing default association). The app opens the file
+      passed on the command line (see App.GetFilePathFromCommandLine).
+    -->
+    <Component Id="FileAssociations" Directory="INSTALLFOLDER" Guid="*">
+      <RegistryKey Root="HKCR" Key="barcodrod.io.image">
+        <RegistryValue Type="string" Value="barcodrod.io Image" KeyPath="yes" />
+        <RegistryValue Name="FriendlyTypeName" Type="string" Value="barcodrod.io Image" />
+        <RegistryKey Key="DefaultIcon">
+          <RegistryValue Type="string" Value="[INSTALLFOLDER]barcodrod.io.exe,0" />
+        </RegistryKey>
+        <RegistryKey Key="shell\open\command">
+          <RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]barcodrod.io.exe&quot; &quot;%1&quot;" />
+        </RegistryKey>
+      </RegistryKey>
+
+      <RegistryKey Root="HKCR" Key="Applications\barcodrod.io.exe">
+        <RegistryValue Name="FriendlyAppName" Type="string" Value="barcodrod.io" />
+        <RegistryKey Key="shell\open\command">
+          <RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]barcodrod.io.exe&quot; &quot;%1&quot;" />
+        </RegistryKey>
+        <RegistryKey Key="SupportedTypes">
+          <RegistryValue Name=".jpg" Type="string" Value="" />
+          <RegistryValue Name=".jpeg" Type="string" Value="" />
+          <RegistryValue Name=".png" Type="string" Value="" />
+          <RegistryValue Name=".bmp" Type="string" Value="" />
+          <RegistryValue Name=".gif" Type="string" Value="" />
+          <RegistryValue Name=".tif" Type="string" Value="" />
+          <RegistryValue Name=".tiff" Type="string" Value="" />
+          <RegistryValue Name=".webp" Type="string" Value="" />
+          <RegistryValue Name=".heif" Type="string" Value="" />
+          <RegistryValue Name=".heic" Type="string" Value="" />
+          <RegistryValue Name=".jfif" Type="string" Value="" />
+          <RegistryValue Name=".ico" Type="string" Value="" />
+          <RegistryValue Name=".svg" Type="string" Value="" />
+          <RegistryValue Name=".jp2" Type="string" Value="" />
+        </RegistryKey>
+      </RegistryKey>
+
+      <RegistryValue Root="HKCR" Key=".jpg\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".jpeg\OpenWithProgids" Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".png\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".bmp\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".gif\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".tif\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".tiff\OpenWithProgids" Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".webp\OpenWithProgids" Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".heif\OpenWithProgids" Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".heic\OpenWithProgids" Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".jfif\OpenWithProgids" Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".ico\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".svg\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+      <RegistryValue Root="HKCR" Key=".jp2\OpenWithProgids"  Name="barcodrod.io.image" Type="string" Value="" />
+    </Component>
+
+    <!--
+      Toast notification COM activator — 1:1 with the MSIX manifest's windows.comServer ExeServer
+      (CLSID DD6D181A-17B6-4A3A-9E66-B9399E0F1184). Lets Windows launch the app to handle toast
+      activations via the Windows App SDK AppNotificationActivated argument.
+    -->
+    <Component Id="ToastActivator" Directory="INSTALLFOLDER" Guid="*">
+      <RegistryKey Root="HKCR" Key="CLSID\{DD6D181A-17B6-4A3A-9E66-B9399E0F1184}">
+        <RegistryValue Type="string" Value="Toast activator" KeyPath="yes" />
+        <RegistryKey Key="LocalServer32">
+          <RegistryValue Type="string" Value="&quot;[INSTALLFOLDER]barcodrod.io.exe&quot; ----AppNotificationActivated:" />
+        </RegistryKey>
+      </RegistryKey>
+    </Component>
+
+    <!-- Single feature containing the harvested files, shortcut and OS integrations. -->
+    <Feature Id="Main" Title="barcodrod.io" Level="1">
+      <ComponentGroupRef Id="PublishedFiles" />
+      <ComponentRef Id="ApplicationShortcut" />
+      <ComponentRef Id="FileAssociations" />
+      <ComponentRef Id="ToastActivator" />
+    </Feature>
+
+  </Package>
+</Wix>

--- a/installer/build-msi.ps1
+++ b/installer/build-msi.ps1
@@ -1,0 +1,113 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Builds the classic (unpackaged) barcodrod.io MSI installer.
+
+.DESCRIPTION
+    Produces a standalone, self-contained MSI that installs barcodrod.io into Program Files
+    with a Start Menu shortcut and ARP/uninstall entry. The app runs fully unpackaged
+    (no MSIX, no Microsoft Store, no Store license) which makes it suitable for offline and
+    locked-down environments (see issue #25).
+
+    The build is intentionally split into three reproducible steps so it works the same
+    locally and in CI (GitHub-hosted runners), with no Visual Studio required:
+
+      1. Packaged build -> generates the app resource index (resources.pri) that WinUI needs.
+         Symbol packaging is disabled because mspdbcmf.exe ships only with full Visual Studio.
+      2. Unpackaged self-contained publish -> produces the runtime payload (exe + all DLLs).
+         MSIX tooling is disabled so no AppxManifest/MakeAppx step runs.
+      3. The resources.pri from (1) is copied next to the published exe, then WiX packages
+         everything into an MSI.
+
+.PARAMETER Version
+    Four-part product version embedded in the MSI (e.g. 2.0.0.0).
+
+.PARAMETER Architecture
+    Target architecture: x64 (default) or arm64.
+
+.PARAMETER Configuration
+    Build configuration. Defaults to Release.
+#>
+[CmdletBinding()]
+param(
+    [string]$Version = "2.0.0.0",
+    [ValidateSet("x64", "arm64")]
+    [string]$Architecture = "x64",
+    [string]$Configuration = "Release"
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot   = Split-Path -Parent $PSScriptRoot
+$project    = Join-Path $repoRoot "barcodrod.io\barcodrod.io.csproj"
+$rid        = "win-$Architecture"
+$tfm        = "net9.0-windows10.0.22000"
+$publishDir = Join-Path $repoRoot "artifacts\publish\$Architecture"
+$msiDir     = Join-Path $repoRoot "artifacts\msi"
+$msiPath    = Join-Path $msiDir "barcodrod.io-$Version-$Architecture.msi"
+$wix        = Join-Path $env:USERPROFILE ".dotnet\tools\wix.exe"
+
+Write-Host "==> [1/4] Building packaged layout to generate resources.pri + processed Assets" -ForegroundColor Cyan
+dotnet build $project -c $Configuration -p:Platform=$Architecture `
+    -p:AppxBundlePlatforms=$Architecture `
+    -p:AppxPackageSigningEnabled=false `
+    -p:AppxSymbolPackageEnabled=false `
+    -p:AppxBundle=Never
+if ($LASTEXITCODE -ne 0) { throw "Packaged build failed (exit $LASTEXITCODE)." }
+
+# The packaged build emits resources.pri under an "AppX" layout for x64; for arm64 it sits at the
+# runtime-identifier root. Resolve both locations robustly.
+$ridRoot = Join-Path $repoRoot "barcodrod.io\bin\$Architecture\$Configuration\$tfm\$rid"
+$priFound = @(
+    (Join-Path $ridRoot "AppX\resources.pri"),
+    (Join-Path $ridRoot "resources.pri")
+) | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $priFound) { throw "resources.pri not found under $ridRoot" }
+
+# Stage resources.pri out of the build tree immediately: the unpackaged publish in step 2 shares the
+# same bin tree and can clobber a resources.pri that sits at the runtime-identifier root (arm64).
+New-Item -ItemType Directory -Force $msiDir | Out-Null
+$priSource = Join-Path $msiDir "resources-$Architecture.pri"
+Copy-Item $priFound $priSource -Force
+
+# The app loads its window icon/logo from \Assets at runtime. Use the committed source Assets
+# folder (architecture-independent and always present) rather than the packaged tile assets, which
+# are only produced for the bundle platform and are otherwise Store-tile-only.
+$assetsSource = Join-Path $repoRoot "barcodrod.io\Assets"
+if (-not (Test-Path (Join-Path $assetsSource "WindowIcon.ico"))) { throw "Source Assets not found at $assetsSource" }
+
+Write-Host "==> [2/4] Publishing unpackaged, self-contained runtime ($rid)" -ForegroundColor Cyan
+if (Test-Path $publishDir) { Remove-Item -Recurse -Force $publishDir }
+dotnet publish $project -c $Configuration -r $rid --self-contained true -p:Platform=$Architecture `
+    -p:WindowsPackageType=None `
+    -p:WindowsAppSDKSelfContained=true `
+    -p:EnableMsixTooling=false `
+    -p:AppxPackage=false `
+    -p:AppxBundle=Never `
+    -p:FileVersion=$Version `
+    -p:InformationalVersion=$Version `
+    -p:IncludeSourceRevisionInInformationalVersion=false `
+    -o $publishDir
+if ($LASTEXITCODE -ne 0) { throw "Unpackaged publish failed (exit $LASTEXITCODE)." }
+
+Write-Host "==> [3/4] Staging resources.pri and Assets into the publish output" -ForegroundColor Cyan
+Copy-Item $priSource (Join-Path $publishDir "resources.pri") -Force
+# The app loads its window icon and logos from \Assets at runtime, but an unpackaged publish does not
+# emit them. Stage the committed source Assets so the installed app shows its icons (1:1 with MSIX).
+$destAssets = Join-Path $publishDir "Assets"
+New-Item -ItemType Directory -Force $destAssets | Out-Null
+Copy-Item (Join-Path $assetsSource "*") $destAssets -Recurse -Force
+
+Write-Host "==> [4/4] Building MSI with WiX" -ForegroundColor Cyan
+if (-not (Test-Path $wix)) { throw "WiX not found at $wix. Install with: dotnet tool install --global wix --version 5.0.2" }
+New-Item -ItemType Directory -Force -Path $msiDir | Out-Null
+& $wix build (Join-Path $PSScriptRoot "barcodrod.io.wxs") `
+    -arch $Architecture `
+    -d "Version=$Version" `
+    -d "PublishDir=$publishDir" `
+    -o $msiPath
+if ($LASTEXITCODE -ne 0) { throw "WiX build failed (exit $LASTEXITCODE)." }
+
+Write-Host ""
+Write-Host "MSI created: $msiPath" -ForegroundColor Green
+Write-Host ("Size: {0:N1} MB" -f ((Get-Item $msiPath).Length / 1MB))


### PR DESCRIPTION
## Summary
Adds an offline-installable **MSI** (x64 + arm64) alongside the Store MSIX, code-signed via the **SignPath Foundation** OSS program. Addresses #25. The Microsoft Store continues to sign/distribute the MSIX; SignPath signs the MSI only.

## What's here (code only)
- `installer/` — WiX v5 installer + `build-msi.ps1` (validated locally for x64 & arm64; 1:1 MSIX parity for file-type associations and the toast COM activator).
- `.github/workflows/release.yml` — build (x64/arm64) → SignPath sign → release. PR=build only, `workflow_dispatch`=test-sign, tag `v*`=release-sign + GitHub Release with SHA256SUMS.
- `.signpath/artifact-config-msi.xml` — deep-signs first-party binaries with enforced product-name/version metadata, signs the MSI.
- App changes for unpackaged execution (`AppPaths` helper, ~44 `ApplicationData.Current` call sites, command-line file activation, crash logging) + csproj cleanup.

## ⚠️ Required before this can sign (maintainer action)
Repo **Settings → Secrets and variables → Actions**:
- Secret `SIGNPATH_API_TOKEN`
- Variables `SIGNPATH_ORGANIZATION_ID`, `SIGNPATH_PROJECT_SLUG`, `SIGNPATH_MSI_ARTIFACT_CONFIGURATION_SLUG`

In SignPath: create signing policies `test-signing` and `release-signing`, upload `.signpath/artifact-config-msi.xml` as the MSI artifact configuration, and install the SignPath GitHub App on this repo.

Draft until the above is configured. The `Code signing policy` section added to the README is a hard SignPath OSS-program requirement.
